### PR TITLE
Fix global type error in client TS config

### DIFF
--- a/public/scripts/tsconfig.json
+++ b/public/scripts/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "../../dist/public/scripts", // Example of a specific output for client scripts if needed
     "noEmit": true, // Keep this true, Vite handles emit
     "lib": ["es2022", "dom", "dom.iterable"],
-    "types": ["jest"],
+    "types": ["jest", "node"],
     // Paths should be relative to baseUrl (which is now project root)
     "paths": {
       "@models/*": ["models/*"],


### PR DESCRIPTION
## Summary
- fix missing Node `global` typings by adding `node` to `types` array in `public/scripts/tsconfig.json`

## Testing
- `npm test`
- `npx eslint .` *(fails: 29 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68449b9d290c83218844316ea6555068