### PR TITLE
Add lobby server tests

### DIFF
--- a/tests/lobbyServer.test.ts
+++ b/tests/lobbyServer.test.ts
@@ -1,0 +1,118 @@
+// tests/lobbyServer.test.ts
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import GameController from '../controllers/GameController.js';
+import { JOINED, LOBBY, ERROR, START_GAME } from '../src/shared/events.js';
+
+interface MockSocket {
+  id: string;
+  join: jest.Mock<void, [string]>;
+  emit: jest.Mock<void, [string, any?]>;
+  on: jest.Mock<void, [string, (data?: any, ack?: Function) => void]>;
+  removeAllListeners: jest.Mock<void, []>;
+  eventHandlers: Record<string, (data?: any, ack?: Function) => void>;
+  simulateIncomingEvent: (event: string, data?: any, ack?: Function) => void;
+  disconnect: jest.Mock<void, []>;
+}
+
+interface MockIOWithEmit {
+  emit: jest.Mock<void, [string, any?]>;
+}
+
+interface MockIO {
+  on: jest.Mock<void, [string, (socket: MockSocket) => void]>;
+  to: jest.Mock<MockIOWithEmit, [string]>;
+  emit: jest.Mock<void, [string, any?]>;
+  sockets: { sockets: Map<string, MockSocket> };
+}
+
+let topLevelEmitMock: jest.Mock<void, [string, any?]>;
+let mockIo: MockIO;
+let hostSocket: MockSocket;
+let gameController: GameController;
+
+function createMockSocket(id: string): MockSocket {
+  const handlers: Record<string, (data?: any, ack?: Function) => void> = {};
+  return {
+    id,
+    join: jest.fn(),
+    emit: jest.fn((event: string, payload?: any) => {
+      topLevelEmitMock(event, payload);
+    }),
+    on: jest.fn((event: string, handler: (data?: any, ack?: Function) => void) => {
+      handlers[event] = handler;
+    }),
+    removeAllListeners: jest.fn(),
+    eventHandlers: handlers,
+    simulateIncomingEvent: (event: string, data?: any, ack?: Function) => {
+      if (handlers[event]) handlers[event](data, ack);
+    },
+    disconnect: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  topLevelEmitMock = jest.fn();
+  mockIo = {
+    on: jest.fn(),
+    to: jest.fn((id: string) => {
+      return { emit: jest.fn((event: string, payload?: any) => topLevelEmitMock(event, payload)) };
+    }),
+    emit: jest.fn((event: string, payload?: any) => topLevelEmitMock(event, payload)),
+    sockets: { sockets: new Map() },
+  };
+  hostSocket = createMockSocket('host-socket');
+  if (mockIo.sockets && mockIo.sockets.sockets) {
+    mockIo.sockets.sockets.set(hostSocket.id, hostSocket);
+  }
+  gameController = new GameController(mockIo as any, 'test-room');
+});
+
+describe('Lobby joining', () => {
+  test('first player join emits lobby state', () => {
+    (gameController['publicHandleJoin'] as Function)(hostSocket, { name: 'Host', id: 'HOST_ID' });
+    expect(hostSocket.emit).toHaveBeenCalledWith(JOINED, { id: 'HOST_ID', name: 'Host', roomId: 'test-room' });
+    const lobbyCall = topLevelEmitMock.mock.calls.find((c) => c[0] === LOBBY);
+    expect(lobbyCall).toBeDefined();
+    if (lobbyCall) {
+      expect(lobbyCall[1]).toEqual(
+        expect.objectContaining({
+          roomId: 'test-room',
+          players: expect.arrayContaining([
+            expect.objectContaining({ id: 'HOST_ID', name: 'Host', disconnected: false }),
+          ]),
+        })
+      );
+    }
+  });
+
+  test('second player join updates lobby for all', () => {
+    (gameController['publicHandleJoin'] as Function)(hostSocket, { name: 'Host', id: 'HOST_ID' });
+    const secondSocket = createMockSocket('socket-b');
+    if (mockIo.sockets && mockIo.sockets.sockets) {
+      mockIo.sockets.sockets.set(secondSocket.id, secondSocket);
+    }
+    (gameController['publicHandleJoin'] as Function)(secondSocket, { name: 'Bob', id: 'BOB_ID' });
+    const lobbyCalls = topLevelEmitMock.mock.calls.filter((c) => c[0] === LOBBY);
+    expect(lobbyCalls.length).toBeGreaterThanOrEqual(2);
+    const lastLobby = lobbyCalls[lobbyCalls.length - 1];
+    expect(lastLobby[1].players.length).toBe(2);
+    expect(lastLobby[1].players).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'HOST_ID' }),
+        expect.objectContaining({ id: 'BOB_ID' }),
+      ])
+    );
+  });
+
+  test('cannot join after game start', () => {
+    (gameController['publicHandleJoin'] as Function)(hostSocket, { name: 'Host', id: 'HOST_ID' });
+    (gameController['handleStartGame'] as Function)({ computerCount: 1, socket: hostSocket });
+    const lateSocket = createMockSocket('late-socket');
+    let ackData: any;
+    (gameController['publicHandleJoin'] as Function)(lateSocket, { name: 'Late', id: 'LATE_ID' }, (res: any) => {
+      ackData = res;
+    });
+    expect(ackData).toEqual({ error: 'Game has already started. Cannot join.' });
+    expect(lateSocket.emit).not.toHaveBeenCalledWith(ERROR, expect.anything());
+  });
+});


### PR DESCRIPTION
## Summary
- cover GameController lobby join logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844a748228c83218472f39fe62352b9