### PR TITLE
Fix rules bullet alignment and clarify special cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,24 +17,24 @@
 
     <!-- Entry‑point for your client modules -->
     <script type="module" src="/scripts/main.ts"></script>
-    
+
     <!-- Fixed card loader for improved card rendering -->
     <script type="module" src="/scripts/fixed-card-loader.js"></script>
-    
+
     <!-- DISABLED SCRIPTS -->
     <!-- <script type="module" src="/scripts/rules-cards.ts"></script> -->
     <!-- <script type="module" src="/scripts/debug-card-loader.js"></script> -->
     <!-- <script src="/scripts/trigger-cards-update.js"></script> -->
-    
+
     <!-- DOM inspector for analyzing card elements -->
     <script src="/scripts/dom-inspector.js"></script>
     <!-- Icon viewer for fullsize icon display -->
     <script src="/scripts/icon-viewer.js"></script>
-    
+
     <!-- Diagnostic and troubleshooting tools -->
     <script src="/scripts/card-loader-diagnostic.js"></script>
     <script src="/scripts/force-card-update.js"></script>
-    
+
     <!-- Style and layout enhancer -->
     <script src="/scripts/style-enforcer.js"></script>
   </head>
@@ -178,26 +178,30 @@
         </div>
 
         <!-- Waiting Room / Invite Link Section (restored) -->
-        <div id="waiting-state" class="hidden" style="width: 100%; text-align: center; margin-top: 2rem;">
+        <div
+          id="waiting-state"
+          class="hidden"
+          style="width: 100%; text-align: center; margin-top: 2rem"
+        >
           <h3 id="waiting-heading">Waiting for players...</h3>
-          <div id="share-link-message" style="margin: 1em 0;">
+          <div id="share-link-message" style="margin: 1em 0">
             <span>Share this link to invite friends:</span>
             <input
               id="invite-link"
               type="text"
               readonly
-              style="width: 60%; max-width: 400px; margin: 0 0.5em;"
+              style="width: 60%; max-width: 400px; margin: 0 0.5em"
             />
-            <button id="copy-link-button" class="header-btn" type="button">
-              Copy Link
-            </button>
+            <button id="copy-link-button" class="header-btn" type="button">Copy Link</button>
             <img
               id="qr-code-image"
               alt="Invite QR Code"
-              style="margin-top: 0.5em; width: 150px; height: 150px; display: none;"
+              style="margin-top: 0.5em; width: 150px; height: 150px; display: none"
             />
           </div>
-          <button id="start-game-button" class="header-btn" type="button" style="margin-top: 1em;">Start Game</button>
+          <button id="start-game-button" class="header-btn" type="button" style="margin-top: 1em">
+            Start Game
+          </button>
         </div>
       </div>
 
@@ -277,104 +281,82 @@
               <div class="rules-details-content">
                 <ul>
                   <li>
-                    <strong>2 (Reset Card):</strong>
-                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0;">
+                    <strong>2 (Reset Card):</strong> A 2 can be played on
+                    <strong>any card</strong> and immediately clears the Discard Pile so the next
+                    player may begin with any card they choose. When a 2 is played, players will see
+                    this icon:
+                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0">
                       <img
                         src="src/shared/Reset-icon.png"
                         alt="Reset"
                         class="rules-icon"
-                        style="width: 3.75em !important; height: 3.75em !important; margin: 0 auto; display: block"
+                        style="
+                          width: 3.75em !important;
+                          height: 3.75em !important;
+                          margin: 0 auto;
+                          display: block;
+                        "
                       />
                     </div>
-                    <ul>
-                      <li>A 2 can be played on <strong>any card</strong>, no matter its value.</li>
-                      <li>
-                        It <strong>resets</strong> the Discard Pile. The pile is cleared, and the next
-                        player can start a new Discard Pile by playing any card they wish.
-                      </li>
-                    </ul>
                   </li>
                   <li>
-                    <strong>5 (Copy Card):</strong>
-                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0;">
+                    <strong>5 (Copy Card):</strong> A 5 <strong>copies the value</strong> of the
+                    card directly beneath it. <em>Example:</em> If a Jack is showing and you play a
+                    5 on it, that 5 now acts like a Jack. If played on an empty pile, it's simply a
+                    normal 5. When a 5 is played, players will see this icon:
+                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0">
                       <img
                         src="src/shared/Copy-icon.png"
                         alt="Copy"
                         class="rules-icon"
-                        style="width: 3.75em !important; height: 3.75em !important; margin: 0 auto; display: block"
+                        style="
+                          width: 3.75em !important;
+                          height: 3.75em !important;
+                          margin: 0 auto;
+                          display: block;
+                        "
                       />
                     </div>
-                    <ul>
-                      <li>
-                        A 5 <strong>copies the value</strong> of the card directly underneath it on
-                        the Discard Pile.
-                      </li>
-                      <li>
-                        <em>Example:</em> If a Jack is showing, and you play a 5 on it, that 5 now
-                        acts like a Jack. The next player must beat a Jack.
-                      </li>
-                      <li>
-                        If a 5 is played on an empty (or just reset) Discard Pile, it just counts as a
-                        normal 5.
-                      </li>
-                    </ul>
                   </li>
                   <li>
-                    <strong>10 (Burn Card):</strong>
-                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0;">
+                    <strong>10 (Burn Card):</strong> A 10 may be played on
+                    <strong>any card</strong> and <strong>burns</strong> the entire Discard Pile. If
+                    no cards remain to start a new pile, the next player can lead with any card.
+                    When a 10 is played, players will see this icon:
+                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0">
                       <img
                         src="src/shared/Burn-icon.png"
                         alt="Burn"
                         class="rules-icon"
-                        style="width: 3.75em !important; height: 3.75em !important; margin: 0 auto; display: block"
+                        style="
+                          width: 3.75em !important;
+                          height: 3.75em !important;
+                          margin: 0 auto;
+                          display: block;
+                        "
                       />
                     </div>
-                    <ul>
-                      <li>A 10 can be played on <strong>any card</strong>.</li>
-                      <li>
-                        When a 10 is played, the
-                        <strong>entire Discard Pile is "burned"</strong> (removed from the game).
-                      </li>
-                      <li>
-                        If there are no cards left to start a new Discard Pile, the next player may
-                        start it with any card from their hand.
-                      </li>
-                    </ul>
                   </li>
                   <li>
-                    <strong>Four of a Kind (Burn & Play Any Value):</strong>
-                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0;">
+                    <strong>Four of a Kind (Burn & Play Any Value):</strong> Playing four cards of
+                    the same value at once also <strong>burns</strong> the Discard Pile, even if
+                    that value is not higher than the top card. In multi-deck games you may use more
+                    than four of the same card to trigger this burn. The pile is removed from the
+                    game, and if nothing is left the next player may begin with any card. When this
+                    happens, players will see this icon:
+                    <div class="rules-icon-block" style="text-align: center; margin: 0.5em 0">
                       <img
                         src="src/shared/4ofakind-icon.png"
                         alt="Four-of-a-kind"
                         class="rules-icon"
-                        style="width: 3.75em !important; height: 3.75em !important; margin: 0 auto; display: block"
+                        style="
+                          width: 3.75em !important;
+                          height: 3.75em !important;
+                          margin: 0 auto;
+                          display: block;
+                        "
                       />
                     </div>
-                    <ul>
-                      <li>
-                        If you play four cards of the same value at once (e.g., four 7s), this also
-                        <strong>burns the Discard Pile</strong>.
-                        <ul>
-                          <li>
-                            <em>Multi-Deck Note:</em> If using multiple decks, you can play more than
-                            four (e.g., five or six of the same card) to activate this burn.
-                          </li>
-                        </ul>
-                      </li>
-                      <li>
-                        <strong>Important:</strong> Four-of-a-Kind can be played even if its value is
-                        <strong>not higher</strong> than the top card of the Discard Pile.
-                      </li>
-                      <li>
-                        The Discard Pile (including the cards that made the Four-of-a-Kind) is removed
-                        from the game.
-                      </li>
-                      <li>
-                        If there are no cards left to start a new Discard Pile, the next player may
-                        start it with any card from their hand.
-                      </li>
-                    </ul>
                   </li>
                 </ul>
               </div>

--- a/public/style.css
+++ b/public/style.css
@@ -694,9 +694,11 @@ body {
 .rules-details-content ol {
   padding-left: 20px;
   margin-top: 5px;
+  list-style-position: outside;
 }
 .rules-details-content li {
   margin-bottom: 8px;
+  line-height: 1.4;
 }
 .rules-details-content strong {
   color: #444;


### PR DESCRIPTION
## Summary
- adjust list spacing for rules content
- rewrite the Special Cards section for clarity with inline icon notes

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npx tsc --noEmit` *(fails: TS2307, TS2707 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b3bb104c832189a5cff7b05d5c0b