### PR TITLE
Improve lobby auto-start and share links

### DIFF
--- a/controllers/GameController.ts
+++ b/controllers/GameController.ts
@@ -333,7 +333,7 @@ export default class GameController {
       maxPlayers: this.gameState.maxPlayers,
     });
 
-    // --- Refined auto-start logic: count actual humans/CPUs in the room ---
+    // --- Refined auto-start logic ---
     const allPlayers = Array.from(this.players.values());
     const numHumansInRoom = allPlayers.filter((p) => !p.isComputer).length;
     const numCPUsInRoom = allPlayers.filter((p) => p.isComputer).length;
@@ -344,6 +344,15 @@ export default class GameController {
     );
 
     if (
+      !this.gameState.started &&
+      numHumansInRoom === 1 &&
+      (playerData.numCPUs || 0) >= 1 &&
+      totalPlayersInRoom === 1
+    ) {
+      const botsToAdd = playerData.numCPUs || 0;
+      this.log(`Auto-starting solo game with ${botsToAdd} CPU bot(s).`);
+      this.handleStartGame({ computerCount: botsToAdd, socket });
+    } else if (
       numHumansInRoom === 1 &&
       numCPUsInRoom >= 1 &&
       totalPlayersInRoom >= 2 &&

--- a/public/scripts/events.ts
+++ b/public/scripts/events.ts
@@ -1,7 +1,7 @@
 import { initializeSocketHandlers } from './socketService.js';
 import * as state from './state.js';
 import * as uiManager from './uiManager.js';
-import { JOIN_GAME } from '../../src/shared/events.js';
+import { JOIN_GAME, START_GAME } from '../../src/shared/events.js';
 
 // --- Message Queue Logic for Single Error Display ---
 let messageQueue: string[] = [];
@@ -456,7 +456,17 @@ export async function initializePageEventListeners() {
   const copyLinkBtn = uiManager.getCopyLinkBtn();
   if (copyLinkBtn) {
     copyLinkBtn.onclick = () => {
-      navigator.clipboard.writeText(window.location.href);
+      const inviteInput = document.getElementById('invite-link') as HTMLInputElement | null;
+      const linkToCopy = inviteInput ? inviteInput.value : window.location.href;
+      navigator.clipboard.writeText(linkToCopy);
+    };
+  }
+
+  const startGameLobbyBtn = document.getElementById('start-game-button');
+  if (startGameLobbyBtn) {
+    startGameLobbyBtn.onclick = () => {
+      const cpuCount = state.getDesiredCpuCount();
+      state.socket.emit(START_GAME, { computerCount: cpuCount });
     };
   }
 
@@ -754,13 +764,19 @@ function handleDealClick() {
   const numHumans = parseInt(totalPlayersInput.value, 10) || 1;
   const numCPUs = parseInt(cpuPlayersInput.value, 10) || 0;
 
+  state.setDesiredCpuCount(numCPUs);
+
+  const currentRoom = state.currentRoom;
+
   const playerDataForEmit = {
     name: name,
     numHumans: numHumans,
     numCPUs: numCPUs,
+    ...(currentRoom ? { id: currentRoom } : {}),
   };
 
   console.log('🎯 Deal button: Validations passed. Joining game with data:', playerDataForEmit);
+  state.saveSession();
   state.socket.emit(JOIN_GAME, playerDataForEmit);
 
   const dealButton = document.getElementById('setup-deal-button') as HTMLButtonElement;

--- a/public/scripts/main.ts
+++ b/public/scripts/main.ts
@@ -14,6 +14,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Clear session on page load
   sessionStorage.removeItem('myId');
   sessionStorage.removeItem('currentRoom');
+  sessionStorage.removeItem('desiredCpuCount');
+
+  const params = new URLSearchParams(window.location.search);
+  const roomFromLink = params.get('room');
+  if (roomFromLink) {
+    sessionStorage.setItem('currentRoom', roomFromLink);
+  }
 
   try {
     await socketReady;

--- a/public/scripts/state.ts
+++ b/public/scripts/state.ts
@@ -58,6 +58,7 @@ export let currentRoom: string | null = null;
 export let pileTransition: boolean = false;
 export let specialEffectsQueue: any[] = []; // TODO: Consider defining a specific type for effects, e.g., SpecialEffect[]
 export let processingEffects: boolean = false;
+export let desiredCpuCount = 0;
 
 export const stateHistory: any[] = []; // TODO: Consider defining a specific type for state history items, e.g., GameStateSnapshot[]
 export let stateIndex: number = -1;
@@ -65,11 +66,14 @@ export let stateIndex: number = -1;
 export function loadSession(): void {
   setMyId(sessionStorage.getItem('myId'));
   setCurrentRoom(sessionStorage.getItem('currentRoom'));
+  const cpuStr = sessionStorage.getItem('desiredCpuCount');
+  if (cpuStr) desiredCpuCount = parseInt(cpuStr, 10) || 0;
 }
 
 export function saveSession(): void {
   if (myId) sessionStorage.setItem('myId', myId);
   if (currentRoom) sessionStorage.setItem('currentRoom', currentRoom);
+  sessionStorage.setItem('desiredCpuCount', desiredCpuCount.toString());
 }
 
 export function setMyId(id: string | null): void {
@@ -77,6 +81,15 @@ export function setMyId(id: string | null): void {
 }
 export function setCurrentRoom(room: string | null): void {
   currentRoom = room;
+}
+
+export function setDesiredCpuCount(count: number): void {
+  desiredCpuCount = count;
+  sessionStorage.setItem('desiredCpuCount', count.toString());
+}
+
+export function getDesiredCpuCount(): number {
+  return desiredCpuCount;
 }
 export function setPileTransition(value: boolean): void {
   pileTransition = value;

--- a/public/scripts/uiManager.ts
+++ b/public/scripts/uiManager.ts
@@ -85,6 +85,16 @@ export function showWaitingState(
   if (waitingHeading) {
     waitingHeading.textContent = `Room: ${roomId} (${currentPlayers}/${maxPlayers})`;
   }
+  const inviteInput = document.getElementById('invite-link') as HTMLInputElement | null;
+  const qrImg = document.getElementById('qr-code-image') as HTMLImageElement | null;
+  if (inviteInput) {
+    const link = `${window.location.origin}?room=${roomId}`;
+    inviteInput.value = link;
+    if (qrImg) {
+      qrImg.src = `https://chart.googleapis.com/chart?cht=qr&chl=${encodeURIComponent(link)}&chs=150x150&chld=L|0`;
+      qrImg.style.display = 'block';
+    }
+  }
   // Render player list
   let playerList = document.getElementById('player-list');
   if (!playerList) {

--- a/public/style.css
+++ b/public/style.css
@@ -1149,6 +1149,42 @@ body {
   box-shadow: 0 1px 4px rgba(255, 195, 0, 0.2);
 }
 
+#start-game-button {
+  background: linear-gradient(135deg, #ffc300 0%, #ffdb4d 100%);
+  color: #1b2e3c !important;
+  border: none;
+}
+
+#start-game-button:hover {
+  background: linear-gradient(135deg, #ffdb4d 0%, #ffe066 100%);
+  color: #1b2e3c !important;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(255, 195, 0, 0.3);
+}
+
+#start-game-button:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(255, 195, 0, 0.2);
+}
+
+#copy-link-button {
+  background: linear-gradient(135deg, #2196f3 0%, #64b5f6 100%);
+  color: #ffffff !important;
+  border: none;
+}
+
+#copy-link-button:hover {
+  background: linear-gradient(135deg, #1976d2 0%, #42a5f5 100%);
+  color: #ffffff !important;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+}
+
+#copy-link-button:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(33, 150, 243, 0.2);
+}
+
 /* General button styling for .header-btn class */
 .header-btn {
   background-color: #007bff; /* Default blue */

--- a/tests/gameFlow.test.ts
+++ b/tests/gameFlow.test.ts
@@ -132,18 +132,13 @@ describe('Game Flow - Single Player vs CPU (auto-start)', () => {
 
   test('Player joins, game auto-starts with 1 CPU, initial state is broadcast', () => {
     const playerData: PlayerJoinDataPayload = { name: 'Player1', numCPUs: 1, id: 'Player1-ID' };
-    // Simulate player joining (should result in lobby state, not started game)
+    // Simulate player joining - should auto start with CPU
     (gameController['publicHandleJoin'] as Function)(globalMockSocket, playerData);
 
-    // After join, game should NOT be started yet (lobby state)
-    expect(gameController['gameState'].started).toBe(false);
+    // After join, game should already be started
+    expect(gameController['gameState'].started).toBe(true);
     expect(gameController['gameState'].players).toContain(playerData.id);
-    expect(gameController['players'].has(playerData.id!)).toBe(true);
-    // No CPUs yet
-    expect(gameController['players'].has('COMPUTER_1')).toBe(false);
-
-    // Now simulate the host starting the game (as the UI would do after lobby)
-    (gameController as any).handleStartGame({ computerCount: 1, socket: globalMockSocket });
+    expect(gameController['players'].has('COMPUTER_1')).toBe(true);
 
     // After start, CPUs should be present and game should be started
     expect(gameController['gameState'].started).toBe(true);

--- a/tests/lobbyForm.test.ts
+++ b/tests/lobbyForm.test.ts
@@ -25,6 +25,7 @@ jest.mock('../public/scripts/state.js', () => {
   return {
     socket: { emit: jest.fn(), on: jest.fn() }, // These will be overridden in beforeEach
     loadSession: jest.fn(),
+    saveSession: jest.fn(),
     $: jest.fn((selector: string) =>
       global.document ? global.document.querySelector(selector) : null
     ),
@@ -38,6 +39,8 @@ jest.mock('../public/scripts/state.js', () => {
     getBackToLobbyButton: jest.fn(() =>
       global.document ? global.document.createElement('button') : null
     ),
+    setDesiredCpuCount: jest.fn(),
+    getDesiredCpuCount: jest.fn(() => 0),
   };
 });
 


### PR DESCRIPTION
## Summary
- auto-start single player games with selected bots
- surface lobby invite link and QR code
- allow starting games from the waiting screen
- store desired bot count in session state
- parse `room` URL param when entering lobby
- style start/copy link buttons to match game theme
- update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b706cb108321a824cdf501306ef9