### PR TITLE
Improve lobby modal with input field

### DIFF
--- a/public/scripts/components/InSessionLobbyModal.ts
+++ b/public/scripts/components/InSessionLobbyModal.ts
@@ -25,7 +25,8 @@ export class InSessionLobbyModal {
     container.innerHTML = `
         <h2>Game Lobby</h2>
         <div class="game-id-section">
-            <p>Room Code: <strong class="game-id"></strong></p>
+            <label for="lobby-room-code" class="visually-hidden">Room Code</label>
+            <input id="lobby-room-code" class="game-id-input" type="text" readonly />
             <button id="copy-game-id-btn" class="btn">Copy</button>
         </div>
         <div class="players-list">
@@ -52,9 +53,9 @@ export class InSessionLobbyModal {
       const startGameBtn = document.getElementById('start-game-btn');
 
       copyBtn?.addEventListener('click', () => {
-        const gameIdEl = document.querySelector('#in-session-lobby-modal .game-id');
-        if (gameIdEl?.textContent) {
-          navigator.clipboard.writeText(gameIdEl.textContent);
+        const gameIdInput = document.getElementById('lobby-room-code') as HTMLInputElement | null;
+        if (gameIdInput?.value) {
+          navigator.clipboard.writeText(gameIdInput.value);
           if (copyBtn instanceof HTMLButtonElement) {
             copyBtn.textContent = 'Copied!';
             setTimeout(() => {
@@ -72,16 +73,16 @@ export class InSessionLobbyModal {
 
   private render(lobbyState: InSessionLobbyState): void {
     const playersContainer = document.getElementById('players-container');
-    const gameIdEl = document.querySelector('#in-session-lobby-modal .game-id');
+    const gameIdInput = document.getElementById('lobby-room-code') as HTMLInputElement | null;
     const startGameBtn = document.getElementById('start-game-btn') as HTMLButtonElement | null;
 
-    if (!playersContainer || !gameIdEl || !startGameBtn) return;
+    if (!playersContainer || !gameIdInput || !startGameBtn) return;
 
     // Hide the lobby form but don't hide the lobby container itself
     uiManager.hideLobbyForm();
 
     // Set the room ID in the modal
-    gameIdEl.textContent = lobbyState.roomId;
+    gameIdInput.value = lobbyState.roomId;
     playersContainer.innerHTML = '';
 
     // Render the player list

--- a/public/styles/base.css
+++ b/public/styles/base.css
@@ -40,6 +40,18 @@ body {
   display: none;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .body-loading #lobby-container {
   visibility: hidden;
   opacity: 0;

--- a/public/styles/lobby.css
+++ b/public/styles/lobby.css
@@ -61,10 +61,17 @@
   border-radius: 6px;
 }
 
-.game-id-section .game-id {
+.game-id-section .game-id-input {
+  flex-grow: 1;
   font-weight: bold;
   font-family: monospace;
   font-size: 1.2rem;
+  padding: 4px 8px;
+  margin-right: 10px;
+  border: 1px solid var(--input-border, #bbb);
+  border-radius: 4px;
+  background-color: #fff;
+  color: #333;
 }
 
 .players-list {


### PR DESCRIPTION
## Summary
- show room code in a readonly input for easy copy
- adjust lobby modal styles for new input
- add `visually-hidden` helper class for accessibility

## Testing
- `bash setup.sh`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68463f30020483218c7641ea64748784