### PR TITLE
Improve in-session lobby modal styling and UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,9 +120,7 @@
                     maxlength="6"
                     style="text-transform: uppercase"
                   />
-                  <button id="join-game-button" class="header-btn" type="button">
-                    Join Game
-                  </button>
+                  <button id="join-game-button" class="header-btn" type="button">Join Game</button>
                 </div>
 
                 <!-- Bots Players Section -->
@@ -191,7 +189,6 @@
             </form>
           </div>
         </div>
-
       </div>
 
       <!-- Game Table -->
@@ -421,8 +418,16 @@
       </div>
     </div>
 
-    <div class="modal modal--hidden" id="in-session-lobby-modal" role="dialog" aria-modal="true" aria-labelledby="in-session-lobby-title">
+    <!-- In-session lobby modal shows players mid-game -->
+    <div
+      class="modal modal--hidden in-session-lobby-modal"
+      id="in-session-lobby-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="in-session-lobby-title"
+    >
       <div class="lobby-modal-container">
+        <!-- game-setup-content shares styling with the main lobby card -->
         <div class="game-setup-content">
           <div class="player-section">
             <h3 id="in-session-lobby-title" class="section-title">Players</h3>
@@ -432,8 +437,12 @@
             <input id="lobby-room-code" class="game-id-input" type="text" readonly maxlength="6" />
             <!-- Reuse header button styling for consistency with main lobby -->
             <button id="copy-link-button" class="header-btn" type="button">Copy Link</button>
-            <button id="start-game-button" class="header-btn" type="button" disabled>LET'S PLAY</button>
+            <button id="start-game-button" class="header-btn" type="button" disabled>
+              LET'S PLAY
+            </button>
           </div>
+          <!-- Toast message for copy link feedback -->
+          <div id="copy-toast" class="toast" aria-live="polite"></div>
         </div>
       </div>
     </div>

--- a/public/scripts/components/InSessionLobbyModal.ts
+++ b/public/scripts/components/InSessionLobbyModal.ts
@@ -46,11 +46,15 @@ export class InSessionLobbyModal extends Modal {
       navigator.clipboard
         .writeText(link)
         .then(() => {
-          const originalText = this.copyLinkBtn.textContent;
-          this.copyLinkBtn.textContent = 'Copied!';
-          setTimeout(() => {
-            this.copyLinkBtn.textContent = originalText;
-          }, 2000);
+          // Show transient toast instead of altering button text
+          const toast = this.modalElement.querySelector('#copy-toast');
+          if (toast) {
+            toast.textContent = 'Link copied!';
+            toast.classList.add('show');
+            setTimeout(() => {
+              toast.classList.remove('show');
+            }, 2000);
+          }
           return undefined;
         })
         .catch(() => {});
@@ -112,11 +116,9 @@ export class InSessionLobbyModal extends Modal {
     this.playersContainer.innerHTML = '';
     lobbyState.players.forEach((player) => {
       const playerEl = document.createElement('div');
-      playerEl.className = `player-item ${player.status.toLowerCase()}`;
-      playerEl.innerHTML = `
-        <span class="player-name">${player.name}${player.id === state.socket?.id ? ' (You)' : ''}</span>
-        <span class="player-status">${player.status}</span>
-      `;
+      // Use simplified pill style. Add 'host' class when applicable
+      playerEl.className = `player-item${player.id === lobbyState.hostId ? ' host' : ''}`;
+      playerEl.textContent = `${player.name}${player.id === state.socket?.id ? ' (You)' : ''}`;
       this.playersContainer.appendChild(playerEl);
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -1360,6 +1360,60 @@ body {
   color: #721c24;
 }
 
+/* --- In-Session Lobby Modal Adjustments --- */
+.in-session-lobby-modal .game-setup-content {
+  max-width: 480px; /* Shrink modal content width */
+  width: 100%;
+}
+
+.in-session-lobby-modal .players-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.in-session-lobby-modal .player-item {
+  background: #fff;
+  border: 2px solid var(--accent);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  color: #1b2e3c;
+  font-weight: 600;
+}
+
+.in-session-lobby-modal .player-item.host::after {
+  content: 'HOST';
+  margin-left: 0.5rem;
+  background: var(--accent);
+  color: #1b2e3c;
+  padding: 0 0.4rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* Toast used for copy link feedback */
+.toast {
+  position: absolute;
+  left: 50%;
+  bottom: -2.5rem;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: var(--header-bg);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.toast.show {
+  opacity: 1;
+}
+
 /* Rule for the action buttons container gap */
 /* #lobby-form > div[style*="justify-content: center"][style*="gap: 0.7rem"] {
   gap: 1.5rem !important;


### PR DESCRIPTION
## Summary
- center the in-session lobby modal and add new toast element
- add styles for smaller modal, player pills and copy toast
- show toast when link is copied and simplify player rendering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684761e506808321a555f6b6db0b1b1e