### PR TITLE
Implement lobby ready-up flow

### DIFF
--- a/models/Player.ts
+++ b/models/Player.ts
@@ -11,7 +11,10 @@ export default class Player {
   public name: string;
   public isComputer: boolean;
   public disconnected: boolean;
-  public status: 'host' | 'invited' | 'joined';
+  // Track the player's status in the lobby. A player can be the host,
+  // invited (before joining), joined (connected but not yet ready),
+  // or ready (clicked the "Let's Play" button).
+  public status: 'host' | 'invited' | 'joined' | 'ready';
 
   constructor(id: string) {
     this.id = id;

--- a/public/index.html
+++ b/public/index.html
@@ -428,15 +428,29 @@
     >
       <div class="lobby-modal-container">
         <div class="game-setup-content">
-          <!-- Players container with new .players-box for custom background -->
-          <div class="player-section players-box">
-            <h3 id="in-session-lobby-title" class="section-title">Users</h3>
-            <div id="players-container" class="players-container"></div>
+          <h3 id="in-session-lobby-title" class="section-title">
+            Waiting for Players...
+          </h3>
+
+          <div class="name-input-section" id="guest-name-section">
+            <input
+              type="text"
+              id="guest-player-name-input"
+              placeholder="Enter Your Name"
+              maxlength="20"
+              required
+            />
           </div>
+
+          <div id="players-container" class="players-container"></div>
+
           <div class="lobby-buttons-row">
-            <!-- Removed code input box as requested -->
-            <button id="copy-link-button" class="header-btn" type="button">Copy Link</button>
-            <button id="start-game-button" class="header-btn" type="button" disabled>LET'S PLAY</button>
+            <button id="copy-link-button" class="header-btn" type="button">
+              Copy Link
+            </button>
+            <button id="ready-up-button" class="header-btn" type="button">
+              Let's Play
+            </button>
           </div>
         </div>
       </div>

--- a/public/scripts/main.ts
+++ b/public/scripts/main.ts
@@ -1,7 +1,8 @@
 // public/scripts/main.ts
 import { initializePageEventListeners } from './events.js';
 import { initializeSocketHandlers } from './socketService.js';
-import { socket, socketReady } from './state.js';
+import { JOIN_GAME } from '@shared/events.ts';
+import { socket, socketReady, setCurrentRoom } from './state.js';
 
 console.log('🚀 [Client] main.ts loaded successfully via Vite!');
 
@@ -103,17 +104,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Only run join link logic if NOT in-session
   const inSession = document.body.classList.contains('in-session');
   if (roomIdFromUrl && !inSession) {
-    sessionStorage.setItem('currentRoom', roomIdFromUrl);
-    // Only update join code inputs if they are empty
-    const joinCodeInputs = document.querySelectorAll<HTMLInputElement>(
-      '#join-code-input, #lobby-room-code'
-    );
-    joinCodeInputs.forEach((input) => {
-      if (!input.value) {
-        input.value = roomIdFromUrl.toUpperCase();
-      }
-    });
-    // Clean up the URL to prevent issues on page refresh
+    setCurrentRoom(roomIdFromUrl);
+    socket.emit(JOIN_GAME, { id: roomIdFromUrl });
     window.history.replaceState({}, document.title, window.location.pathname);
   }
   // --- END: New logic for handling join links ---

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -32,6 +32,7 @@ export const MESSAGE: string = 'message'; // Generic message from server
 
 // Lobby events
 export const LOBBY_STATE_UPDATE: string = 'lobby-state-update';
+export const PLAYER_READY: string = 'player-ready';
 export const SEND_INVITE: string = 'send-invite';
 
 // Optional: You could also define these as an enum if you prefer,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,10 +32,12 @@ export interface GameStateData {
   lastRealCard: Card | null;
 }
 
+// Represents a player in the lobby. `status` shows whether the
+// player is the host, just joined, or has clicked the ready button.
 export interface LobbyPlayer {
   id: string;
   name: string;
-  status: 'host' | 'invited' | 'joined';
+  status: 'host' | 'invited' | 'joined' | 'ready';
 }
 
 export interface InSessionLobbyState {


### PR DESCRIPTION
## Summary
- add `ready` status to `Player` and shared types
- update game lobby logic with PLAYER_READY event
- auto-start game when all humans are ready
- add player name input and ready button to lobby modal
- handle room URL auto-join and ready events on the client
- update InSessionLobbyModal tests for new flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68477e80dbc88321806606a28c85ef9d