### PR TITLE
Fix session lobby initialization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,8 +39,7 @@
     <!-- Style and layout enhancer -->
     <script src="/scripts/style-enforcer.js"></script>
   </head>
-  <body class="body-loading" style="min-height: 100vh; display: flex; flex-direction: column"
-        onload="document.body.classList.add('body-loading')">
+  <body class="body-loading" style="min-height: 100vh; display: flex; flex-direction: column">
     <!-- Header removed per user request -->
 
     <div id="game-container">
@@ -50,7 +49,7 @@
 
       <main class="main-content" id="main-content">
         <!-- Lobby Screen -->
-        <div class="lobby hidden" id="lobby-container" style="opacity:0;visibility:hidden;">
+        <div class="lobby hidden" id="lobby-container">
           <div id="lobby-outer-card" class="lobby-modal-container">
             <div id="lobby-inner-content" class="game-setup-content">
               <div class="setup-header">

--- a/public/scripts/main.ts
+++ b/public/scripts/main.ts
@@ -20,10 +20,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   // sessionStorage.removeItem('desiredCpuCount');
 
   try {
-    // Instantiate the in-session lobby modal so it can listen for events
-    new InSessionLobbyModal();
-
     await socketReady;
+
+    // Instantiate the in-session lobby modal after the socket is ready so
+    // event listeners can attach correctly
+    new InSessionLobbyModal();
 
     // Attach socket event listeners after socket is ready
     socket.on('connect', () => {


### PR DESCRIPTION
## Summary
- wait for socket to be ready before creating `InSessionLobbyModal`
- remove `onload` attribute that re-applied `body-loading`
- drop inline `opacity` and `visibility` from `#lobby-container`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd3ebd508321aa8c4d94f4c64f76