### PR TITLE
Fix session lobby initialization

### DIFF
--- a/public/scripts/components/InSessionLobbyModal.ts
+++ b/public/scripts/components/InSessionLobbyModal.ts
@@ -232,6 +232,19 @@ export class InSessionLobbyModal extends Modal {
   }
 }
 
+let modalInstance: InSessionLobbyModal | null = null;
+
+/**
+ * Retrieve a singleton instance of {@link InSessionLobbyModal}.
+ * This ensures event listeners are only registered once.
+ */
+export function getInSessionLobbyModal(): InSessionLobbyModal {
+  if (!modalInstance) {
+    modalInstance = new InSessionLobbyModal();
+  }
+  return modalInstance;
+}
+
 // Place this function OUTSIDE the class body:
 export function setupInSessionLobbyModal(roomId: string): void {
   const modal = document.getElementById('in-session-lobby-modal');

--- a/public/scripts/main.ts
+++ b/public/scripts/main.ts
@@ -1,7 +1,7 @@
 // public/scripts/main.ts
 import { JOIN_GAME } from '@shared/events.ts';
 
-import { InSessionLobbyModal } from './components/InSessionLobbyModal.js';
+import { getInSessionLobbyModal } from './components/InSessionLobbyModal.js';
 import { initializePageEventListeners } from './events.js';
 import { initializeSocketHandlers } from './socketService.js';
 import { socket, socketReady, setCurrentRoom } from './state.js';
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Instantiate the in-session lobby modal after the socket is ready so
     // event listeners can attach correctly
-    new InSessionLobbyModal();
+    getInSessionLobbyModal();
 
     // Attach socket event listeners after socket is ready
     socket.on('connect', () => {

--- a/public/scripts/render.ts
+++ b/public/scripts/render.ts
@@ -1,4 +1,4 @@
-import { InSessionLobbyModal } from './components/InSessionLobbyModal.js';
+import { getInSessionLobbyModal } from './components/InSessionLobbyModal.js';
 import {
   Card as CardType,
   GameStateData,
@@ -6,17 +6,11 @@ import {
   InSessionLobbyState,
 } from '../../src/shared/types.js';
 
-// Store a singleton instance of the modal
-let inSessionLobbyModal: InSessionLobbyModal | null = null;
-
 export function renderLobbyState(lobbyState: InSessionLobbyState): void {
   console.log('[DEBUG] renderLobbyState called', lobbyState);
-  if (!inSessionLobbyModal) {
-    inSessionLobbyModal = new InSessionLobbyModal();
-    console.log('[DEBUG] Created new InSessionLobbyModal instance');
-  }
+  const modal = getInSessionLobbyModal();
   // @ts-expect-error: render is private, but we need to call it here
-  inSessionLobbyModal.render(lobbyState);
+  modal.render(lobbyState);
   // Check modal visibility after render
   const modalEl = document.getElementById('in-session-lobby-modal');
   if (modalEl) {


### PR DESCRIPTION
## Summary
- ensure `InSessionLobbyModal` is created only once
- centralize modal creation via new `getInSessionLobbyModal` helper
- use helper in `main.ts` and `render.ts`

## Testing
- `npm test` *(fails: InSessionLobbyModal.test and Rules modal interactions)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4f5887c83219d468cabcd7d9e42