### PR TITLE
Introduce lobby manager scaffolding

### DIFF
--- a/controllers/GameController.ts
+++ b/controllers/GameController.ts
@@ -474,6 +474,14 @@ export default class GameController {
     // If the first player is a CPU, do NOT call playComputerTurn.
   }
 
+  /**
+   * Public wrapper around the private start logic so external callers (like the Lobby)
+   * can trigger the game start without exposing the full internal options type.
+   */
+  public startGame(computerCount = 0, socket?: Socket): Promise<void> {
+    return this.handleStartGame({ computerCount, socket });
+  }
+
   private handlePlayCard(socket: Socket, { cardIndices, zone }: PlayData): void {
     const playerId = this.socketIdToPlayerId.get(socket.id);
     this.log(

--- a/models/Lobby.ts
+++ b/models/Lobby.ts
@@ -1,0 +1,99 @@
+import { Server, Socket } from 'socket.io';
+
+import Player from './Player.js';
+import GameController from '../controllers/GameController.js';
+import { LOBBY_STATE_UPDATE, GAME_STARTED } from '../src/shared/events.js';
+
+export interface LobbyPlayer {
+  id: string;
+  name: string;
+  ready: boolean;
+}
+
+export default class Lobby {
+  public roomId: string;
+  private io: Server;
+  public players: Map<string, Player>;
+  public hostId: string | null;
+  private sockets: Map<string, Socket>;
+  private gameController: GameController | null;
+
+  constructor(roomId: string, io: Server) {
+    this.roomId = roomId;
+    this.io = io;
+    this.players = new Map();
+    this.hostId = null;
+    this.sockets = new Map();
+    this.gameController = null;
+  }
+
+  addPlayer(socket: Socket, playerName: string): void {
+    const player = new Player(socket.id);
+    player.name = playerName;
+    player.socketId = socket.id;
+    this.players.set(socket.id, player);
+    this.sockets.set(socket.id, socket);
+    if (!this.hostId) this.hostId = socket.id;
+    socket.join(this.roomId);
+    this.broadcastLobbyState();
+  }
+
+  removePlayer(socketId: string): void {
+    this.players.delete(socketId);
+    this.sockets.delete(socketId);
+    if (socketId === this.hostId) {
+      const first = this.players.keys().next().value;
+      this.hostId = first || null;
+    }
+    this.broadcastLobbyState();
+  }
+
+  setPlayerReady(socketId: string, ready: boolean): void {
+    const player = this.players.get(socketId);
+    if (player) {
+      player.ready = ready;
+      this.broadcastLobbyState();
+      this.checkIfReadyToStart();
+    }
+  }
+
+  private broadcastLobbyState(): void {
+    const state = {
+      roomId: this.roomId,
+      players: Array.from(this.players.values()).map((p) => ({
+        id: p.id,
+        name: p.name,
+        ready: p.ready,
+      })),
+      hostId: this.hostId,
+    };
+    this.io.to(this.roomId).emit(LOBBY_STATE_UPDATE, state);
+  }
+
+  private checkIfReadyToStart(): void {
+    const allReady = Array.from(this.players.values()).every((p) => p.ready);
+    if (allReady && this.players.size > 0) {
+      this.startGame();
+    }
+  }
+
+  private startGame(): void {
+    console.log(`Lobby ${this.roomId} ready to start the game`);
+    this.gameController = new GameController(this.io, this.roomId);
+    for (const [socketId, player] of this.players.entries()) {
+      const socket = this.sockets.get(socketId);
+      if (socket) {
+        this.gameController.publicHandleJoin(socket, { id: player.id, name: player.name });
+      }
+    }
+    const hostSocket = this.hostId ? this.sockets.get(this.hostId) : undefined;
+    this.gameController
+      .startGame(0, hostSocket)
+      .then(() => {
+        this.io.to(this.roomId).emit(GAME_STARTED);
+      })
+      .catch((err) => {
+        console.error('Failed to start game:', err);
+      });
+  }
+}

--- a/models/LobbyManager.ts
+++ b/models/LobbyManager.ts
@@ -1,0 +1,53 @@
+import { Server } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+
+import Lobby from './Lobby.js';
+
+export default class LobbyManager {
+  private static instance: LobbyManager;
+  private lobbies: Map<string, Lobby>;
+  private io: Server;
+
+  private constructor(io: Server) {
+    this.io = io;
+    this.lobbies = new Map();
+  }
+
+  static getInstance(io?: Server): LobbyManager {
+    if (!LobbyManager.instance) {
+      if (!io) {
+        throw new Error('LobbyManager requires io instance on first call');
+      }
+      LobbyManager.instance = new LobbyManager(io);
+    }
+    return LobbyManager.instance;
+  }
+
+  createLobby(): Lobby {
+    const roomId = uuidv4().slice(0, 6);
+    const lobby = new Lobby(roomId, this.io);
+    this.lobbies.set(roomId, lobby);
+    return lobby;
+  }
+
+  getLobby(roomId: string): Lobby | undefined {
+    return this.lobbies.get(roomId);
+  }
+
+  removeLobby(roomId: string): void {
+    this.lobbies.delete(roomId);
+  }
+
+  findLobbyBySocketId(socketId: string): Lobby | undefined {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.players.has(socketId)) {
+        return lobby;
+      }
+    }
+    return undefined;
+  }
+
+  get allLobbies(): IterableIterator<Lobby> {
+    return this.lobbies.values();
+  }
+}

--- a/models/Player.ts
+++ b/models/Player.ts
@@ -11,6 +11,7 @@ export default class Player {
   public name: string;
   public isComputer: boolean;
   public disconnected: boolean;
+  public ready: boolean;
 
   constructor(id: string) {
     this.id = id;
@@ -20,6 +21,7 @@ export default class Player {
     this.name = '';
     this.isComputer = false;
     this.disconnected = false;
+    this.ready = false;
   }
 
   setHand(cards: Card[]): void {

--- a/public/index.html
+++ b/public/index.html
@@ -17,24 +17,24 @@
 
     <!-- Entry‑point for your client modules -->
     <script type="module" src="/scripts/main.ts"></script>
-    
+
     <!-- Fixed card loader for improved card rendering -->
     <script type="module" src="/scripts/fixed-card-loader.js"></script>
-    
+
     <!-- DISABLED SCRIPTS -->
     <!-- <script type="module" src="/scripts/rules-cards.ts"></script> -->
     <!-- <script type="module" src="/scripts/debug-card-loader.js"></script> -->
     <!-- <script src="/scripts/trigger-cards-update.js"></script> -->
-    
+
     <!-- DOM inspector for analyzing card elements -->
     <script src="/scripts/dom-inspector.js"></script>
     <!-- Icon viewer for fullsize icon display -->
     <script src="/scripts/icon-viewer.js"></script>
-    
+
     <!-- Diagnostic and troubleshooting tools -->
     <script src="/scripts/card-loader-diagnostic.js"></script>
     <script src="/scripts/force-card-update.js"></script>
-    
+
     <!-- Style and layout enhancer -->
     <script src="/scripts/style-enforcer.js"></script>
   </head>
@@ -178,26 +178,30 @@
         </div>
 
         <!-- Waiting Room / Invite Link Section (restored) -->
-        <div id="waiting-state" class="hidden" style="width: 100%; text-align: center; margin-top: 2rem;">
+        <div
+          id="waiting-state"
+          class="hidden"
+          style="width: 100%; text-align: center; margin-top: 2rem"
+        >
           <h3 id="waiting-heading">Waiting for players...</h3>
-          <div id="share-link-message" style="margin: 1em 0;">
+          <div id="share-link-message" style="margin: 1em 0">
             <span>Share this link to invite friends:</span>
             <input
               id="invite-link"
               type="text"
               readonly
-              style="width: 60%; max-width: 400px; margin: 0 0.5em;"
+              style="width: 60%; max-width: 400px; margin: 0 0.5em"
             />
-            <button id="copy-link-button" class="header-btn" type="button">
-              Copy Link
-            </button>
+            <button id="copy-link-button" class="header-btn" type="button">Copy Link</button>
             <img
               id="qr-code-image"
               alt="Invite QR Code"
-              style="margin-top: 0.5em; width: 150px; height: 150px; display: none;"
+              style="margin-top: 0.5em; width: 150px; height: 150px; display: none"
             />
           </div>
-          <button id="start-game-button" class="header-btn" type="button" style="margin-top: 1em;">Start Game</button>
+          <button id="start-game-button" class="header-btn" type="button" style="margin-top: 1em">
+            Start Game
+          </button>
         </div>
       </div>
 
@@ -281,19 +285,16 @@
                     <ul>
                       <li>A 2 can be played on <strong>any card</strong>, no matter its value.</li>
                       <li>
-                        It <strong>resets</strong> the Discard Pile. The pile is cleared, and the next
-                        player can start a new Discard Pile by playing any card they wish.
+                        It <strong>resets</strong> the Discard Pile. The pile is cleared, and the
+                        next player can start a new Discard Pile by playing any card they wish.
                       </li>
                     </ul>
-                    <li class="rules-icon-desc">When a 2 is played you will see this icon:
+                    <div class="rules-icon-desc">
+                      When a 2 is played you will see this icon:
                       <div class="rules-icon-block">
-                        <img
-                          src="src/shared/Reset-icon.png"
-                          alt="Reset"
-                          class="rules-icon"
-                        />
+                        <img src="src/shared/Reset-icon.png" alt="Reset" class="rules-icon" />
                       </div>
-                    </li>
+                    </div>
                   </li>
                   <li>
                     <strong>5 (Copy Card):</strong>
@@ -307,19 +308,16 @@
                         acts like a Jack. The next player must beat a Jack.
                       </li>
                       <li>
-                        If a 5 is played on an empty (or just reset) Discard Pile, it just counts as a
-                        normal 5.
+                        If a 5 is played on an empty (or just reset) Discard Pile, it just counts as
+                        a normal 5.
                       </li>
                     </ul>
-                    <li class="rules-icon-desc">When a 5 is played you will see this icon:
+                    <div class="rules-icon-desc">
+                      When a 5 is played you will see this icon:
                       <div class="rules-icon-block">
-                        <img
-                          src="src/shared/Copy-icon.png"
-                          alt="Copy"
-                          class="rules-icon"
-                        />
+                        <img src="src/shared/Copy-icon.png" alt="Copy" class="rules-icon" />
                       </div>
-                    </li>
+                    </div>
                   </li>
                   <li>
                     <strong>10 (Burn Card):</strong>
@@ -334,15 +332,12 @@
                         start it with any card from their hand.
                       </li>
                     </ul>
-                    <li class="rules-icon-desc">When a 10 is played you will see this icon:
+                    <div class="rules-icon-desc">
+                      When a 10 is played you will see this icon:
                       <div class="rules-icon-block">
-                        <img
-                          src="src/shared/Burn-icon.png"
-                          alt="Burn"
-                          class="rules-icon"
-                        />
+                        <img src="src/shared/Burn-icon.png" alt="Burn" class="rules-icon" />
                       </div>
-                    </li>
+                    </div>
                   </li>
                   <li>
                     <strong>Four of a Kind (Burn & Play Any Value):</strong>
@@ -352,25 +347,26 @@
                         <strong>burns the Discard Pile</strong>.
                         <ul>
                           <li>
-                            <em>Multi-Deck Note:</em> If using multiple decks, you can play more than
-                            four (e.g., five or six of the same card) to activate this burn.
+                            <em>Multi-Deck Note:</em> If using multiple decks, you can play more
+                            than four (e.g., five or six of the same card) to activate this burn.
                           </li>
                         </ul>
                       </li>
                       <li>
-                        <strong>Important:</strong> Four-of-a-Kind can be played even if its value is
-                        <strong>not higher</strong> than the top card of the Discard Pile.
+                        <strong>Important:</strong> Four-of-a-Kind can be played even if its value
+                        is <strong>not higher</strong> than the top card of the Discard Pile.
                       </li>
                       <li>
-                        The Discard Pile (including the cards that made the Four-of-a-Kind) is removed
-                        from the game.
+                        The Discard Pile (including the cards that made the Four-of-a-Kind) is
+                        removed from the game.
                       </li>
                       <li>
                         If there are no cards left to start a new Discard Pile, the next player may
                         start it with any card from their hand.
                       </li>
                     </ul>
-                    <li class="rules-icon-desc">When a Four of a Kind is played you will see this icon:
+                    <div class="rules-icon-desc">
+                      When a Four of a Kind is played you will see this icon:
                       <div class="rules-icon-block">
                         <img
                           src="src/shared/4ofakind-icon.png"
@@ -378,7 +374,7 @@
                           class="rules-icon"
                         />
                       </div>
-                    </li>
+                    </div>
                   </li>
                 </ul>
               </div>

--- a/public/scripts/models/Player.d.ts
+++ b/public/scripts/models/Player.d.ts
@@ -8,6 +8,7 @@ export default class Player {
   name: string;
   isComputer: boolean;
   disconnected: boolean;
+  ready: boolean;
   constructor(id: string);
   setHand(cards: Card[]): void;
   setUpCards(cards: Card[]): void;

--- a/public/scripts/render.ts
+++ b/public/scripts/render.ts
@@ -547,29 +547,14 @@ export function showCardEvent(cardValue: number | string | null, type: string): 
 }
 
 /**
-
+ * Reveal the main game area. This is called once the game starts.
+ */
+export function playArea(): void {
+  const mainContent = document.getElementById('main-content');
   if (mainContent) mainContent.classList.add('game-active');
 }
 
 /**
-
- * Display a lobby link for inviting other players
- */
-export function lobbyLink({ id }: { id: string }): void {
-  const lobbyContainer = document.getElementById('lobby-container');
-  const lobbyFormContent = document.getElementById('lobby-form-content');
-  const waitingStateDiv = document.getElementById('waiting-state');
-
-  if (lobbyContainer) lobbyContainer.classList.remove('hidden');
-  if (lobbyFormContent) lobbyFormContent.classList.add('hidden');
-  if (waitingStateDiv) waitingStateDiv.classList.remove('hidden');
-
-  const heading = document.getElementById('waiting-heading');
-  if (heading) heading.textContent = `Room: ${id}`;
-
-  const inviteInput = document.getElementById('invite-link') as HTMLInputElement | null;
-  if (inviteInput) inviteInput.value = window.location.href;
-=======
  * Update the invite link and QR code for the lobby.
  * @param param0 Object containing the room id.
  */

--- a/public/scripts/socketHandlers.ts
+++ b/public/scripts/socketHandlers.ts
@@ -4,7 +4,12 @@
 import { renderGameState } from './render.js';
 import * as state from './state.js';
 import { showLobbyForm, showWaitingState, showGameTable, showError } from './uiManager.js';
-import { JOINED, PLAYER_JOINED, LOBBY, STATE_UPDATE, REJOIN } from '../../src/shared/events.js';
+import {
+  JOINED,
+  LOBBY_STATE_UPDATE,
+  STATE_UPDATE,
+  REJOIN,
+} from '../../src/shared/events.js';
 import { GameStateData } from '../../src/shared/types.js';
 
 export async function initializeSocketHandlers(): Promise<void> {
@@ -23,14 +28,14 @@ export async function initializeSocketHandlers(): Promise<void> {
     state.saveSession();
   });
 
-  state.socket.on(PLAYER_JOINED, () => {
-    // Handle player joined logic
-  });
+  // Legacy PLAYER_JOINED event removed
 
-  state.socket.on(LOBBY, (data: { roomId: string; players: any[]; maxPlayers: number }) => {
-    const { roomId, players, maxPlayers } = data;
-    showWaitingState(roomId, players.length, maxPlayers, players);
-  });
+  state.socket.on(
+    LOBBY_STATE_UPDATE,
+    (data: { roomId: string; players: { id: string; name: string; ready: boolean }[] }) => {
+      showWaitingState(data.roomId, data.players.length, data.players.length, data.players);
+    }
+  );
 
   state.socket.on(STATE_UPDATE, (s: GameStateData) => {
     console.log('Received STATE_UPDATE:', s); // Added for debugging

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -22,6 +22,13 @@ export const PICK_UP_PILE: string = 'pick-up-pile'; // Player chooses to pick up
 export const CARD_PLAYED: string = 'card-played'; // A card was successfully played
 export const PILE_PICKED_UP: string = 'pile-picked-up'; // The pile was picked up by a player
 
+// Lobby system events
+export const CREATE_LOBBY: string = 'createLobby';
+export const LOBBY_CREATED: string = 'lobbyCreated';
+export const JOIN_LOBBY: string = 'joinLobby';
+export const PLAYER_READY: string = 'playerReady';
+export const LOBBY_STATE_UPDATE: string = 'lobbyStateUpdate';
+
 // Game state and updates
 export const STATE_UPDATE: string = 'state-update'; // Generic state update from server
 export const SPECIAL_CARD_EFFECT: string = 'specialCardEffect'; // Renamed from SPECIAL_CARD, Indicates a special card effect (e.g., 2, 5, 10 played)

--- a/tests/eslint.config.ts
+++ b/tests/eslint.config.ts
@@ -6,6 +6,7 @@ import {
   LOBBY,
   STATE_UPDATE,
   NEXT_TURN,
+  START_GAME,
 } from '../src/shared/events.js';
 
 // --- Type Definitions for Mocks ---


### PR DESCRIPTION
## Summary
- add ready flag to Player for pre-game status
- create Lobby class and singleton LobbyManager
- update server to handle lobby creation and joining
- extend socket events with lobby-centric events
- expose client helpers for lobby socket operations
- clean up render merge issue and finalize new lobby tests
- tidy lobby imports
- fix comment block in render.ts
- integrate lobby startGame logic with GameController
- use shared error event constant
- polish lobby UI integration
- fix HTML nesting in rules list

## Testing
- `npm test --silent`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6849db184c2083218e3547edf03ba58a