### PR TITLE
Implement lobby cleanup on disconnect

### DIFF
--- a/models/Lobby.ts
+++ b/models/Lobby.ts
@@ -1,0 +1,109 @@
+import { Server, Socket } from 'socket.io';
+
+import Player from './Player.js';
+import GameController from '../controllers/GameController.js';
+import { LOBBY_STATE_UPDATE, GAME_STARTED } from '../src/shared/events.js';
+
+export interface LobbyPlayer {
+  id: string;
+  name: string;
+  ready: boolean;
+}
+
+export default class Lobby {
+  public roomId: string;
+  private io: Server;
+  public players: Map<string, Player>;
+  public hostId: string | null;
+  private sockets: Map<string, Socket>;
+  private gameController: GameController | null;
+
+  constructor(roomId: string, io: Server) {
+    this.roomId = roomId;
+    this.io = io;
+    this.players = new Map();
+    this.hostId = null;
+    this.sockets = new Map();
+    this.gameController = null;
+  }
+
+  addPlayer(socket: Socket, playerName: string): void {
+    const player = new Player(socket.id);
+    player.name = playerName;
+    player.socketId = socket.id;
+    this.players.set(socket.id, player);
+    this.sockets.set(socket.id, socket);
+    if (!this.hostId) this.hostId = socket.id;
+    socket.join(this.roomId);
+    this.broadcastLobbyState();
+  }
+
+  /**
+   * Remove a player from the lobby.
+   * @param socketId - The socket ID of the player to remove.
+   * @returns `true` if the lobby is now empty, otherwise `false`.
+   */
+  removePlayer(socketId: string): boolean {
+    const socket = this.sockets.get(socketId);
+    if (socket) {
+      socket.leave(this.roomId);
+    }
+    this.players.delete(socketId);
+    this.sockets.delete(socketId);
+    if (socketId === this.hostId) {
+      const first = this.players.keys().next().value;
+      this.hostId = first || null;
+    }
+    this.broadcastLobbyState();
+    return this.players.size === 0;
+  }
+
+  setPlayerReady(socketId: string, ready: boolean): void {
+    const player = this.players.get(socketId);
+    if (player) {
+      player.ready = ready;
+      this.broadcastLobbyState();
+      this.checkIfReadyToStart();
+    }
+  }
+
+  private broadcastLobbyState(): void {
+    const state = {
+      roomId: this.roomId,
+      players: Array.from(this.players.values()).map((p) => ({
+        id: p.id,
+        name: p.name,
+        ready: p.ready,
+      })),
+      hostId: this.hostId,
+    };
+    this.io.to(this.roomId).emit(LOBBY_STATE_UPDATE, state);
+  }
+
+  private checkIfReadyToStart(): void {
+    const allReady = Array.from(this.players.values()).every((p) => p.ready);
+    if (allReady && this.players.size > 0) {
+      this.startGame();
+    }
+  }
+
+  private startGame(): void {
+    console.log(`Lobby ${this.roomId} ready to start the game`);
+    this.gameController = new GameController(this.io, this.roomId);
+    for (const [socketId, player] of this.players.entries()) {
+      const socket = this.sockets.get(socketId);
+      if (socket) {
+        this.gameController.publicHandleJoin(socket, { id: player.id, name: player.name });
+      }
+    }
+    const hostSocket = this.hostId ? this.sockets.get(this.hostId) : undefined;
+    this.gameController
+      .startGame(0, hostSocket)
+      .then(() => {
+        this.io.to(this.roomId).emit(GAME_STARTED);
+      })
+      .catch((err) => {
+        console.error('Failed to start game:', err);
+      });
+  }
+}

--- a/models/LobbyManager.ts
+++ b/models/LobbyManager.ts
@@ -1,0 +1,58 @@
+import { Server } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+
+import Lobby from './Lobby.js';
+
+export default class LobbyManager {
+  private static instance: LobbyManager;
+  private lobbies: Map<string, Lobby>;
+  private io: Server;
+
+  private constructor(io: Server) {
+    this.io = io;
+    this.lobbies = new Map();
+  }
+
+  static getInstance(io?: Server): LobbyManager {
+    if (!LobbyManager.instance) {
+      if (!io) {
+        throw new Error('LobbyManager requires io instance on first call');
+      }
+      LobbyManager.instance = new LobbyManager(io);
+    }
+    return LobbyManager.instance;
+  }
+
+  createLobby(): Lobby {
+    const roomId = uuidv4().slice(0, 6);
+    const lobby = new Lobby(roomId, this.io);
+    this.lobbies.set(roomId, lobby);
+    return lobby;
+  }
+
+  getLobby(roomId: string): Lobby | undefined {
+    return this.lobbies.get(roomId);
+  }
+
+  removeLobby(roomId: string): void {
+    this.lobbies.delete(roomId);
+  }
+
+  /**
+   * Find the lobby that contains a socket ID.
+   * Iterates through all lobbies rather than using a cache to
+   * keep the logic straightforward.
+   */
+  findLobbyBySocketId(socketId: string): Lobby | undefined {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.players.has(socketId)) {
+        return lobby;
+      }
+    }
+    return undefined;
+  }
+
+  get allLobbies(): IterableIterator<Lobby> {
+    return this.lobbies.values();
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -75,8 +75,8 @@ function startServer(port: number, retries = 0) {
     socket.on('disconnect', () => {
       const lobby = lobbyManager.findLobbyBySocketId(socket.id);
       if (lobby) {
-        lobby.removePlayer(socket.id);
-        if (lobby.players.size === 0) {
+        const isEmpty = lobby.removePlayer(socket.id);
+        if (isEmpty) {
           lobbyManager.removeLobby(lobby.roomId);
         }
       }


### PR DESCRIPTION
## Summary
- restore `Lobby` and `LobbyManager` classes
- add boolean return to `Lobby.removePlayer` and clear socket refs
- scan all lobbies in `LobbyManager.findLobbyBySocketId`
- clean up empty lobbies on disconnect in `server.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684a274f496c83218eb2bb9f5942fff7