### PR TITLE
Implement lobby management

### DIFF
--- a/models/Lobby.ts
+++ b/models/Lobby.ts
@@ -1,0 +1,33 @@
+import { Socket } from 'socket.io';
+
+export interface LobbyPlayer {
+  socket: Socket;
+  name: string;
+  ready: boolean;
+}
+
+export default class Lobby {
+  public roomId: string;
+  public players: Map<string, LobbyPlayer>;
+
+  constructor(roomId: string) {
+    this.roomId = roomId;
+    this.players = new Map();
+  }
+
+  addPlayer(socket: Socket, name: string): void {
+    socket.join(this.roomId);
+    this.players.set(socket.id, { socket, name, ready: false });
+  }
+
+  removePlayer(socketId: string): void {
+    this.players.delete(socketId);
+  }
+
+  setPlayerReady(socketId: string, ready: boolean): void {
+    const player = this.players.get(socketId);
+    if (player) {
+      player.ready = ready;
+    }
+  }
+}

--- a/models/LobbyManager.ts
+++ b/models/LobbyManager.ts
@@ -1,0 +1,47 @@
+import { Server } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+import Lobby from './Lobby.js';
+
+export default class LobbyManager {
+  private static instance: LobbyManager | null = null;
+  private lobbies: Map<string, Lobby> = new Map();
+  private io: Server;
+
+  private constructor(io: Server) {
+    this.io = io;
+  }
+
+  static getInstance(io?: Server): LobbyManager {
+    if (!LobbyManager.instance) {
+      if (!io) {
+        throw new Error('LobbyManager requires a Socket.IO server instance');
+      }
+      LobbyManager.instance = new LobbyManager(io);
+    }
+    return LobbyManager.instance;
+  }
+
+  createLobby(): Lobby {
+    const roomId = uuidv4().slice(0, 6);
+    const lobby = new Lobby(roomId);
+    this.lobbies.set(roomId, lobby);
+    return lobby;
+  }
+
+  getLobby(roomId: string): Lobby | undefined {
+    return this.lobbies.get(roomId);
+  }
+
+  findLobbyBySocketId(id: string): Lobby | undefined {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.players.has(id)) {
+        return lobby;
+      }
+    }
+    return undefined;
+  }
+
+  removeLobby(roomId: string): void {
+    this.lobbies.delete(roomId);
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,14 @@ import http from 'http';
 
 import express, { Express, Request, Response } from 'express';
 import { Server as SocketIOServer } from 'socket.io';
+import LobbyManager from './models/LobbyManager.js';
+import {
+  CREATE_LOBBY,
+  LOBBY_CREATED,
+  JOIN_LOBBY,
+  PLAYER_READY,
+  ERROR,
+} from './src/shared/events.js';
 
 const app: Express = express();
 
@@ -27,22 +35,12 @@ function startServer(port: number, retries = 0) {
   server = http.createServer(app);
   // Attach Socket.IO to the same HTTP server
   const io: SocketIOServer = new SocketIOServer(server, { cors: { origin: '*' } });
-  
-  // Replace GameRoomManager with LobbyManager
-  import LobbyManager from './models/LobbyManager.js';
-  import {
-    CREATE_LOBBY,
-    LOBBY_CREATED,
-    JOIN_LOBBY,
-    PLAYER_READY,
-    ERROR,
-  } from './src/shared/events.js';
-  
+
   const lobbyManager = LobbyManager.getInstance(io);
 
   io.on('connection', (socket) => {
     console.log(`New connection: ${socket.id}`);
-    
+
     socket.on(CREATE_LOBBY, (playerName: string, ack?: (roomId: string) => void) => {
       console.log(`Socket ${socket.id} creating lobby with name: ${playerName}`);
       const lobby = lobbyManager.createLobby();

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -34,6 +34,9 @@ export const MESSAGE: string = 'message'; // Generic message from server
 export const LOBBY_STATE_UPDATE: string = 'lobby-state-update';
 export const PLAYER_READY: string = 'player-ready';
 export const SEND_INVITE: string = 'send-invite';
+export const CREATE_LOBBY: string = 'create-lobby';
+export const LOBBY_CREATED: string = 'lobby-created';
+export const JOIN_LOBBY: string = 'join-lobby';
 
 // Optional: You could also define these as an enum if you prefer,
 // though string constants are very common for event names.

--- a/tests/lobbyManager.test.ts
+++ b/tests/lobbyManager.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { Socket } from 'socket.io';
+import LobbyManager from '../models/LobbyManager.js';
+
+function createMockSocket(id: string): Socket {
+  return { id, join: jest.fn() } as unknown as Socket;
+}
+
+describe('LobbyManager and Lobby', () => {
+  beforeEach(() => {
+    (LobbyManager as any).instance = null;
+  });
+
+  test('create lobby and add player', () => {
+    const manager = LobbyManager.getInstance({} as any);
+    const lobby = manager.createLobby();
+    const socket = createMockSocket('s1');
+    lobby.addPlayer(socket, 'Alice');
+    expect(lobby.players.size).toBe(1);
+    const player = lobby.players.get('s1');
+    expect(player).toEqual(expect.objectContaining({ name: 'Alice', ready: false }));
+  });
+
+  test('find lobby by socket id', () => {
+    const manager = LobbyManager.getInstance({} as any);
+    const lobby = manager.createLobby();
+    const socket = createMockSocket('s1');
+    lobby.addPlayer(socket, 'Alice');
+    const found = manager.findLobbyBySocketId('s1');
+    expect(found).toBe(lobby);
+  });
+
+  test('remove lobby', () => {
+    const manager = LobbyManager.getInstance({} as any);
+    const lobby = manager.createLobby();
+    manager.removeLobby(lobby.roomId);
+    expect(manager.getLobby(lobby.roomId)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `Lobby` model and `LobbyManager` singleton
- expose lobby events in `src/shared/events.ts`
- wire `LobbyManager` into `server.ts`
- add Jest tests for lobby manager logic

## Testing
- `npm test` *(fails: InSessionLobbyModal, main.ts, rulesModal)*

------
https://chatgpt.com/codex/tasks/task_e_684a274cd1f08321bda6dabe7ec1ec6c