### PR TITLE
Implement lobby ready tracking

### DIFF
--- a/models/Lobby.ts
+++ b/models/Lobby.ts
@@ -1,0 +1,72 @@
+import { Socket, Server } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+import { InSessionLobbyState, LobbyPlayer } from '../src/shared/types.js';
+import { LOBBY_STATE_UPDATE } from '../src/shared/events.js';
+
+interface LobbyPlayerRecord extends LobbyPlayer {
+  socketId: string;
+}
+
+export default class Lobby {
+  public readonly roomId: string;
+  public players: Map<string, LobbyPlayerRecord> = new Map();
+  public hostId: string | null = null;
+
+  constructor(private io: Server, roomId?: string) {
+    this.roomId = roomId ?? uuidv4();
+  }
+
+  addPlayer(socket: Socket, name: string): void {
+    const player: LobbyPlayerRecord = {
+      id: socket.id,
+      socketId: socket.id,
+      name,
+      status: this.hostId ? 'joined' : 'host',
+      ready: this.hostId ? false : true,
+    };
+    if (!this.hostId) this.hostId = player.id;
+    this.players.set(socket.id, player);
+    socket.join(this.roomId);
+    this.broadcastState();
+  }
+
+  removePlayer(socketId: string): void {
+    this.players.delete(socketId);
+    if (this.hostId === socketId) {
+      const next = Array.from(this.players.values())[0];
+      this.hostId = next ? next.id : null;
+      if (next) next.status = 'host';
+    }
+    this.broadcastState();
+  }
+
+  /**
+   * Mark a player as ready or not ready in the lobby.
+   * If the player is found, their `ready` property is updated.
+   */
+  setPlayerReady(socketId: string, ready: boolean): void {
+    const player = this.players.get(socketId);
+    if (player) {
+      player.ready = ready;
+      player.status = ready ? 'ready' : player.status;
+    }
+  }
+
+  getState(): InSessionLobbyState {
+    const players: LobbyPlayer[] = Array.from(this.players.values()).map((p) => ({
+      id: p.id,
+      name: p.name,
+      status: p.status,
+      ready: p.ready,
+    }));
+    return {
+      roomId: this.roomId,
+      hostId: this.hostId,
+      players,
+    };
+  }
+
+  private broadcastState(): void {
+    this.io.to(this.roomId).emit(LOBBY_STATE_UPDATE, this.getState());
+  }
+}

--- a/models/LobbyManager.ts
+++ b/models/LobbyManager.ts
@@ -1,0 +1,39 @@
+import { Server, Socket } from 'socket.io';
+import Lobby from './Lobby.js';
+
+export default class LobbyManager {
+  private static instance: LobbyManager | null = null;
+  private lobbies: Map<string, Lobby> = new Map();
+
+  private constructor(private io: Server) {}
+
+  static getInstance(io: Server): LobbyManager {
+    if (!LobbyManager.instance) {
+      LobbyManager.instance = new LobbyManager(io);
+    }
+    return LobbyManager.instance;
+  }
+
+  createLobby(): Lobby {
+    const lobby = new Lobby(this.io);
+    this.lobbies.set(lobby.roomId, lobby);
+    return lobby;
+  }
+
+  getLobby(roomId: string): Lobby | undefined {
+    return this.lobbies.get(roomId);
+  }
+
+  removeLobby(roomId: string): void {
+    this.lobbies.delete(roomId);
+  }
+
+  findLobbyBySocketId(socketId: string): Lobby | undefined {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.players.has(socketId)) {
+        return lobby;
+      }
+    }
+    return undefined;
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -69,6 +69,7 @@ function startServer(port: number, retries = 0) {
       const lobby = lobbyManager.findLobbyBySocketId(socket.id);
       if (lobby) {
         lobby.setPlayerReady(socket.id, ready);
+        io.to(lobby.roomId).emit(LOBBY_STATE_UPDATE, lobby.getState());
       }
     });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,6 +38,7 @@ export interface LobbyPlayer {
   id: string;
   name: string;
   status: 'host' | 'invited' | 'joined' | 'ready';
+  ready?: boolean;
 }
 
 export interface InSessionLobbyState {


### PR DESCRIPTION
## Summary
- track per-player readiness in Lobby type definition
- create minimal Lobby and LobbyManager implementations
- allow server to broadcast lobby state when readiness changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a274e11748321bd4596c9807ff2de