### PR TITLE
Add LobbyManager tests and implementation

### DIFF
--- a/models/LobbyManager.ts
+++ b/models/LobbyManager.ts
@@ -1,0 +1,74 @@
+import { Server, Socket } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+
+interface PlayerInfo {
+  socket: Socket;
+  name: string;
+  ready: boolean;
+}
+
+export class Lobby {
+  public roomId: string;
+  public players: Map<string, PlayerInfo> = new Map();
+  private manager: LobbyManager;
+
+  constructor(roomId: string, manager: LobbyManager) {
+    this.roomId = roomId;
+    this.manager = manager;
+  }
+
+  addPlayer(socket: Socket, name: string): void {
+    socket.join(this.roomId);
+    this.players.set(socket.id, { socket, name, ready: false });
+  }
+
+  setPlayerReady(socketId: string, ready: boolean): void {
+    const p = this.players.get(socketId);
+    if (p) {
+      p.ready = ready;
+    }
+  }
+
+  removePlayer(socketId: string): void {
+    this.players.delete(socketId);
+    if (this.players.size === 0) {
+      this.manager.removeLobby(this.roomId);
+    }
+  }
+}
+
+export default class LobbyManager {
+  private static instance: LobbyManager | null = null;
+  public lobbies: Map<string, Lobby> = new Map();
+
+  private constructor(private io: Server) {}
+
+  static getInstance(io: Server): LobbyManager {
+    if (!LobbyManager.instance) {
+      LobbyManager.instance = new LobbyManager(io);
+    }
+    return LobbyManager.instance;
+  }
+
+  createLobby(): Lobby {
+    const roomId = uuidv4().slice(0, 6);
+    const lobby = new Lobby(roomId, this);
+    this.lobbies.set(roomId, lobby);
+    return lobby;
+  }
+
+  getLobby(roomId: string): Lobby | undefined {
+    return this.lobbies.get(roomId);
+  }
+
+  removeLobby(roomId: string): void {
+    this.lobbies.delete(roomId);
+  }
+
+  findLobbyBySocketId(socketId: string): Lobby | undefined {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.players.has(socketId)) return lobby;
+    }
+    return undefined;
+  }
+}

--- a/tests/lobbyManager.test.ts
+++ b/tests/lobbyManager.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import LobbyManager from '../models/LobbyManager.js';
+import { Server, Socket } from 'socket.io';
+
+interface MockSocket {
+  id: string;
+  join: jest.Mock;
+  emit: jest.Mock;
+  on: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+function createMockSocket(id: string): MockSocket {
+  return {
+    id,
+    join: jest.fn(),
+    emit: jest.fn(),
+    on: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+describe('LobbyManager', () => {
+  let io: Partial<Server>;
+  let lobbyManager: LobbyManager;
+
+  beforeEach(() => {
+    io = {
+      to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+    } as unknown as Server;
+    // LobbyManager is a singleton; ensure each test gets a fresh instance
+    lobbyManager = LobbyManager.getInstance(io as Server);
+    // Clear all existing lobbies between tests
+    for (const lobby of lobbyManager.lobbies.values()) {
+      lobbyManager.removeLobby(lobby.roomId);
+    }
+  });
+
+  it('createLobby returns a unique roomId', () => {
+    const lobbyA = lobbyManager.createLobby();
+    const lobbyB = lobbyManager.createLobby();
+    expect(lobbyA.roomId).not.toBe(lobbyB.roomId);
+  });
+
+  it('joining with wrong ID fails', () => {
+    lobbyManager.createLobby();
+    const lobby = lobbyManager.getLobby('bad-id');
+    expect(lobby).toBeUndefined();
+  });
+
+  it('removes a lobby when last player disconnects', () => {
+    const lobby = lobbyManager.createLobby();
+    const socket = createMockSocket('s1');
+    lobby.addPlayer(socket as unknown as Socket, 'Alice');
+    lobby.removePlayer('s1');
+    expect(lobbyManager.getLobby(lobby.roomId)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement LobbyManager with basic lobby tracking
- remove a lobby when its last player disconnects
- add unit tests for LobbyManager functionality

## Testing
- `npm test -- -t LobbyManager`
- `npm test` *(fails: 3 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684a2755a48c8321bef6aa53d3ae1b6d